### PR TITLE
Set up Vite for library build and enhance plugin compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,22 @@
 {
   "name": "ts-runtime-picker",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./webpack-loader": {
+      "types": "./dist/webpack-loader.d.ts",
       "import": "./dist/webpack-loader.js",
-      "require": "./dist/webpack-loader.js",
-      "types": "./dist/webpack-loader.d.ts"
+      "require": "./dist/webpack-loader.js"
     },
     "./vite-plugin": {
+      "types": "./dist/vite-plugin.d.ts",
       "import": "./dist/vite-plugin.js",
-      "require": "./dist/vite-plugin.js",
-      "types": "./dist/vite-plugin.d.ts"
+      "require": "./dist/vite-plugin.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## 🚀 Purpose

This PR sets up the Vite build configuration for creating a library with multiple entry points and improves plugin compatibility by updating TypeScript runtime exports.

---

## 🧑‍💻 Changes

- Added `vite.config.ts` for configuring Vite to build a library with multiple entry points.
- Included CommonJS compatibility and TypeScript type declarations in the build process.
- Updated `TsRuntimePickerVitePlugin` to support both named and default exports.
- Modified `package.json` build script to use Vite instead of the previous `tsc` workflow.
