### PR TITLE
fix: update dependabot configuration to group all updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "fix"
+    groups:
+      all-updates:
+        patterns:
+          - "*"


### PR DESCRIPTION
## 🚀 Purpose

Make dependabot use one PR for all updates to merge conflicts i the package lock.
